### PR TITLE
Improve loading order & more example env data

### DIFF
--- a/App/MagentoDotEnv.php
+++ b/App/MagentoDotEnv.php
@@ -24,8 +24,8 @@ class MagentoDotEnv
         $rootDirectory = __DIR__;
 
         while ($rootDirectory != '/') {
-            if (is_dir($rootDirectory.'/app/etc') && file_exists($rootDirectory.'/app/etc/.env')) {
-                $dotenv = Dotenv::createMutable($rootDirectory.'/app/etc/');
+            if (is_dir($rootDirectory.'/app/etc') && (file_exists($rootDirectory.'/app/etc/.env') || file_exists($rootDirectory.'/.env'))) {
+                $dotenv = Dotenv::createMutable([$rootDirectory, $rootDirectory.'/app/etc/']);
                 $dotenv->load();
                 $dotenv->required(['APP_ENV', 'DB_DATABASE', 'DB_USERNAME', 'DB_PASSWORD', 'CRYPT_KEY']);
                 $this->loadEnvironments($rootDirectory);
@@ -44,13 +44,20 @@ class MagentoDotEnv
     protected function loadEnvironments($rootDirectory): void
     {
         $this->setEnvironment('APP_ENV', $_ENV['APP_ENV'] ?: 'development');
-        $this->setEnvironment('MAGE_MODE', $_ENV['APP_ENV'] !== 'production' ? 'developer' : 'production');
 
-        // override .env values
-        if (file_exists($rootDirectory.'/app/etc/.env.'.$_ENV['APP_ENV'])) {
-            $dotenv = Dotenv::createMutable($rootDirectory.'/app/etc/', '.env.'.$_ENV['APP_ENV']);
-            $dotenv->load();
-        }
+        $dotenv = Dotenv::createMutable([$rootDirectory, $rootDirectory.'/app/etc/'], array_filter([...$this->envToArray($_ENV['LOAD_BEFORE'] ?? ''), '.env.'.$_ENV['APP_ENV'], '.env', ...$this->envToArray($_ENV['LOAD_AFTER'] ?? '')]), false);
+        $dotenv->load();
+
+        $this->setEnvironment('MAGE_MODE', $_ENV['APP_ENV'] !== 'production' ? 'developer' : 'production');
+    }
+
+    /**
+     * Turn space seperated paths into array, ignoring escape sequences.
+     */
+    protected function envToArray(string $envValue = ''): array
+    {
+        $array = preg_split('/(?<!\\\) /', $envValue);
+        return preg_replace('/(?<!\\\) /', ' ', $array);
     }
 
     /**

--- a/App/MagentoDotEnv.php
+++ b/App/MagentoDotEnv.php
@@ -25,7 +25,7 @@ class MagentoDotEnv
 
         while ($rootDirectory != '/') {
             if (is_dir($rootDirectory.'/app/etc') && (file_exists($rootDirectory.'/app/etc/.env') || file_exists($rootDirectory.'/.env'))) {
-                $dotenv = Dotenv::createMutable([$rootDirectory, $rootDirectory.'/app/etc/']);
+                $dotenv = Dotenv::createMutable([$rootDirectory, $rootDirectory.'/app/etc/'], shortCircuit: false);
                 $dotenv->load();
                 $dotenv->required(['APP_ENV', 'DB_DATABASE', 'DB_USERNAME', 'DB_PASSWORD', 'CRYPT_KEY']);
                 $this->loadEnvironments($rootDirectory);

--- a/Example/env.php
+++ b/Example/env.php
@@ -36,7 +36,7 @@ return [
     'session' => [
         // possible: files, redis, db, memcache
         'save' => $_ENV['SESSION_DRIVER'] ?? 'files',
-        'save_path' => $_ENV['SESSION_SAVE_PATH'],
+        'save_path' => $_ENV['SESSION_SAVE_PATH'] ?? null,
         'db_connection' => $_ENV['SESSION_DATABASE_CONNECTION'] ?? 'default',
         'table' => $_ENV['SESSION_DATABASE_TABLE'] ?? 'session',
         'gc_probability' => 1,
@@ -45,7 +45,7 @@ return [
         'redis' => [
             'host' => $_ENV['REDIS_SESSION_HOST'] ?? '127.0.0.1',
             'port' => $_ENV['REDIS_SESSION_PORT'] ?? '6379',
-            'server' => $_ENV['REDIS_SESSION_SERVER'],
+            'server' => $_ENV['REDIS_SESSION_SERVER'] ?? null,
             'timeout' => $_ENV['REDIS_SESSION_TIMEOUT'] ?? '2.5',
             'persistent_identifier' => '',
             'database' => $_ENV['REDIS_SESSION_DATABASE'] ?? '0',

--- a/Example/env.php
+++ b/Example/env.php
@@ -34,7 +34,34 @@ return [
     'x-frame-options' => 'SAMEORIGIN',
     'MAGE_MODE' => $_ENV['MAGE_MODE'],
     'session' => [
-        'save' => 'files'
+        // possible: files, redis, db, memcache
+        'save' => $_ENV['SESSION_DRIVER'] ?? 'files',
+        'save_path' => $_ENV['SESSION_SAVE_PATH'],
+        'db_connection' => $_ENV['SESSION_DATABASE_CONNECTION'] ?? 'default',
+        'table' => $_ENV['SESSION_DATABASE_TABLE'] ?? 'session',
+        'gc_probability' => 1,
+        'gc_divisor' => 10000,
+        'gc_maxlifetime' => 1440,
+        'redis' => [
+            'host' => $_ENV['REDIS_SESSION_HOST'] ?? '127.0.0.1',
+            'port' => $_ENV['REDIS_SESSION_PORT'] ?? '6379',
+            'server' => $_ENV['REDIS_SESSION_SERVER'],
+            'timeout' => $_ENV['REDIS_SESSION_TIMEOUT'] ?? '2.5',
+            'persistent_identifier' => '',
+            'database' => $_ENV['REDIS_SESSION_DATABASE'] ?? '0',
+            'compression_threshold' => '2048',
+            'compression_library' => 'gzip',
+            'log_level' => '1',
+            'max_concurrency' => $_ENV['REDIS_SESSION_MAX_CONCURRENCY'] ?? '18',
+            'break_after_frontend' => '5',
+            'break_after_adminhtml' => '30',
+            'first_lifetime' => '600',
+            'bot_first_lifetime' => '60',
+            'bot_lifetime' => '7200',
+            'disable_locking' => $_ENV['REDIS_SESSION_DISABLE_LOCKING'] ?? '0',
+            'min_lifetime' => '60',
+            'max_lifetime' => '2592000'
+        ],
     ],
     'cache_types' => [
         'config' => 1,
@@ -64,5 +91,11 @@ return [
         'log_everything' => 1,
         'query_time_threshold' => '0.001',
         'include_stacktrace' => 1
-    ]
+    ],
+    'queue' => [
+        'consumers_wait_for_messages' => $_ENV['QUEUE_CONSUMERS_WAIT_FOR_MESSAGES'] ?? 0,
+    ],
+    'graphql' => [
+        'disable_introspection' => $_ENV['APP_ENV'] === 'production',
+    ],
 ];

--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@ Credits to [this package](https://github.com/Pr00xxy/magento2-dotenv) which insp
 
 ## Installation
 - `composer require justbetter/dotenv`
-- Copy the `.env.example` [example file](Example/.env.example) to `app/etc/.env` and fill in your environment variables.
+- Copy the `.env.example` [example file](Example/.env.example) to `app/etc/.env`, or. `.env` and fill in your environment variables.
 - Replace the `env.php` with this [one](Example/env.php) and commit it to source control.
 - `bin/magento setup:upgrade`
 
 ## Extending the environments
 You can override specific environments with the APP_ENV variable in the dot env filename. [example](Example/.env.development.example). Copy the file to `app/etc/` and modify for any specified environment.
 
+You can also load additional .env files by defining them in `LOAD_BEFORE` (allowing the values in these files to be overridden) or `LOAD_AFTER` (allowing the values in these files to override all others) with your extra .env files you would like to load.
+
 ## Disabled the writer to env.php
 Because of the Writer class of magento 2 the `env.php` get rewrited every time. I disabled this functionality because the `env.php` file is not static. The cache types are not reset every time when you run `bin/magento setup:upgrade`.
 
 ## Compatibility
-The module is tested on Magento version 2.3.x
+The module is tested on Magento version 2.4.x
 
 ## Ideas, bugs or suggestions?
 Please create a [issue](https://github.com/justbetter/magento2-sentry/issues) or a [pull request](https://github.com/justbetter/magento2-sentry/pulls).

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Module to overwrite and set environment variables",
   "type": "magento2-module",
   "require": {
-    "php": ">=7.0",
+    "php": ">=8.0",
     "magento/framework": "*",
     "vlucas/phpdotenv": "^5.4"
   },


### PR DESCRIPTION
This PR adds the following features to .env loading:
- Allow placing and loading the .env(s) from `/` and `/app/etc/`
- Fix the loading order between the .env and .env.developer, where .env.developer would override the .env before.
- Load an env before all others using `LOAD_BEFORE=".env.before .env.another"` Allowing all values to be overridden by all other envs
- Load an env after all others using `LOAD_AFTER=".env.after .env.another"` allowing those files to override all other envs